### PR TITLE
緯度経度からタイル番号を計算する関数を堅牢にした

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "typescript": "^4.1.3"
   },
   "scripts": {
-    "test": "jest",
+    "test": "ZOOM=24 jest",
     "build": "rimraf ./dist && tsc",
     "start": "npm run build && sls offline",
     "deploy:dev": "npm run build && sls deploy --stage=dev",

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -27,6 +27,12 @@ test('Should calculate tile indexes from coordinates(2)', () => {
     expect(y).toEqual(6606499)
 })
 
+test('Should not calculate tile indexes with NaN', () => {
+  const lat = 35.68122
+  const lng = 139.76755
+  expect(() => coord2XY([lat, lng], NaN)).toThrow()
+})
+
 describe('IncrementP Verification API', () => {
   test('Should verify an address via API', async () => {
     const address ="盛岡市盛岡駅西通町２丁目９番地１号 マリオス10F"

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,6 +11,9 @@ export const hashXY = (x: number, y: number): string => {
 
 export const coord2XY = (coord: [lat: number, lng: number], zoom: number): { x: number, y: number } => {
     const [lat, lng] = coord
+    if(Number.isNaN(lat) || Number.isNaN(lng) || Number.isNaN(zoom)) {
+        throw new Error(`Invalid lat, lng or zoom: ${JSON.stringify({ lat, lng, zoom })}`)
+    }
     const x = Math.floor((lng / 180 + 1) * 2**zoom / 2)
 	const y = Math.floor((- Math.log(Math.tan((45 + lat / 2) * Math.PI / 180)) + Math.PI) * 2**zoom / (2 * Math.PI))
     return { x, y }

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -4,7 +4,7 @@ import { handler } from './public'
 
 test('should specify the ZOOM environmental variable.', () => {
     const ZOOM = parseInt(process.env.ZOOM, 10)
-    expect(ZOOM).not.toBe(isNaN)
+    expect(ZOOM).not.toBe(NaN)
     expect(typeof ZOOM).toBe('number')
 })
 
@@ -21,7 +21,7 @@ test('should get estate ID', async () => {
 
     expect(body).toEqual([
         {
-            ID: "03-6b6d-f315-17a6-ba28"
+            ID: "03-5759-4a9a-6195-71a0"
         }
     ])
 })


### PR DESCRIPTION
緯度経度からタイル番号を計算する関数の不具合を修正しました。
テスト環境で zoom 値を指定しなくてもテストが通ってしまっていた不具合を修正するため、zoom に `NaN` を与えた時にエラーが帰るようにしました。