### PR TITLE
Rate limit

### DIFF
--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -10,15 +10,41 @@ export const authenticate = async (apiKey: string, accessToken: string) => {
     const { Item: item } = await docclient.get(getItemInput).promise()
 
     if(!item) {
-        return false
+        return { authenticated: false }
     }
 
     if(item && item.accessToken === hashToken(accessToken)) {
-        return true
+        return { authenticated: true, lastRequest: item.lastRequest }
     }
-    return false
+    return { authenticated: false }
 }
 
+export const update = async (apiKey:string, timestamp: number | false) => {
+    const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
+    let updateItemInput: AWS.DynamoDB.DocumentClient.UpdateItemInput
+    if(timestamp == false) {
+        updateItemInput = {
+            TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
+            Key: { apiKey },
+            UpdateExpression: 'remove #lastRequest',
+            ExpressionAttributeNames: {
+                '#lastRequest': 'lastRequest',
+            },
+        }
+    } else {
+        updateItemInput = {
+            TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
+            Key: { apiKey },
+            UpdateExpression: 'set #lastRequest = :timstamp',
+            ExpressionAttributeNames: {
+                '#lastRequest': 'lastRequest',
+            },
+            ExpressionAttributeValues: {
+                ':timestamp': timestamp || null
+            }
+        } 
+    }
+}
 
 export const store = async (estateId: string, zoom: number, address: object) => {
     const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -35,19 +35,6 @@ export const updateTimestamp = async (apiKey:string, timestamp: number) => {
     return await docclient.update(updateItemInput).promise()
 }
 
-export const removeTimestamp = async (apiKey:string) => {
-    const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
-    const updateItemInput: AWS.DynamoDB.DocumentClient.UpdateItemInput = {
-        TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
-        Key: { apiKey },
-        UpdateExpression: 'remove #lastRequestAt',
-        ExpressionAttributeNames: {
-            '#lastRequestAt': 'lastRequestAt',
-        },
-    }
-    return await docclient.update(updateItemInput).promise()
-}
-
 export const store = async (estateId: string, zoom: number, address: object) => {
     const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
     const putItemInput: AWS.DynamoDB.DocumentClient.PutItemInput = {

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -19,31 +19,33 @@ export const authenticate = async (apiKey: string, accessToken: string) => {
     return { authenticated: false }
 }
 
-export const updateTimestamp = async (apiKey:string, timestamp: number | false) => {
+export const updateTimestamp = async (apiKey:string, timestamp: number) => {
     const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
-    let updateItemInput: AWS.DynamoDB.DocumentClient.UpdateItemInput
-    if(timestamp == false) {
-        updateItemInput = {
-            TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
-            Key: { apiKey },
-            UpdateExpression: 'remove #lastRequestAt',
-            ExpressionAttributeNames: {
-                '#lastRequestAt': 'lastRequestAt',
-            },
+    const updateItemInput: AWS.DynamoDB.DocumentClient.UpdateItemInput = {
+        TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
+        Key: { apiKey },
+        UpdateExpression: 'set #lastRequestAt = :timestamp',
+        ExpressionAttributeNames: {
+            '#lastRequestAt': 'lastRequestAt',
+        },
+        ExpressionAttributeValues: {
+            ':timestamp': timestamp
         }
-    } else {
-        updateItemInput = {
-            TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
-            Key: { apiKey },
-            UpdateExpression: 'set #lastRequestAt = :timstamp',
-            ExpressionAttributeNames: {
-                '#lastRequestAt': 'lastRequestAt',
-            },
-            ExpressionAttributeValues: {
-                ':timestamp': timestamp || null
-            }
-        } 
+    } 
+    return await docclient.update(updateItemInput).promise()
+}
+
+export const removeTimestamp = async (apiKey:string) => {
+    const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
+    const updateItemInput: AWS.DynamoDB.DocumentClient.UpdateItemInput = {
+        TableName: process.env.AWS_DYNAMODB_API_KEY_TABLE_NAME,
+        Key: { apiKey },
+        UpdateExpression: 'remove #lastRequestAt',
+        ExpressionAttributeNames: {
+            '#lastRequestAt': 'lastRequestAt',
+        },
     }
+    return await docclient.update(updateItemInput).promise()
 }
 
 export const store = async (estateId: string, zoom: number, address: object) => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -51,8 +51,3 @@ export const hashToken = (accessToken: string) => {
     return crypto.scryptSync(accessToken, process.env.ACCESS_TOKEN_SALT, 10).toString()
 }
 
-export const sleep = (milliseconds: number) => {
-    return new Promise(resolve => {
-        setTimeout(resolve, milliseconds)
-    })
-}  

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -50,3 +50,9 @@ export const decapitalize = (headers: { [key : string]: string | undefined }) =>
 export const hashToken = (accessToken: string) => {
     return crypto.scryptSync(accessToken, process.env.ACCESS_TOKEN_SALT, 10).toString()
 }
+
+export const sleep = (second: number) => {
+    return new Promise(resolve => {
+        setTimeout(resolve, second * 1000)
+    })
+}  

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -36,7 +36,7 @@ test('should get estate ID', async () => {
 test('should get estate ID with details if authenticated', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.authenticate = async () => true
+    dynamodb.authenticate = async () => { authenticated: true }
     dynamodb.store = async () => void 0
     
     const event = {
@@ -86,7 +86,7 @@ test('should return 400 with empty address', async () => {
 test('should return 403 if authenticated.', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.authenticate = async () => false
+    dynamodb.authenticate = async () => { authenticated: false }
 
     const event = {
         queryStringParameters: {

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -16,7 +16,9 @@ test.skip('should get estate ID', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
     dynamodb.store = async () => void 0
-    
+    dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
+    dynamodb.removeTimestamp = async (apiKey: string) => void 0
+
     const event = {
         queryStringParameters: {
             q: '盛岡市盛岡駅西通町２丁目９番地１号 マリオス10F'
@@ -37,7 +39,9 @@ test.skip('should get estate ID', async () => {
 test('should get estate ID with details if authenticated', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.authenticate = async () => { authenticated: true }
+    dynamodb.authenticate = async () => ({ authenticated: true })
+    dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
+    dynamodb.removeTimestamp = async (apiKey: string) => void 0
     dynamodb.store = async () => void 0
     
     const event = {
@@ -73,6 +77,29 @@ test('should get estate ID with details if authenticated', async () => {
     ])
 })
 
+test('should get estate ID after 1sec.', async () => {
+    // mock
+    const dynamodb = require('./lib/dynamodb')
+    const now = Date.now()
+    dynamodb.authenticate = async () => ({ authenticated: true, lastRequestAt: now })
+    dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
+    dynamodb.removeTimestamp = async (apiKey: string) => void 0
+    dynamodb.store = async () => void 0
+    
+    const event = {
+        queryStringParameters: {
+            q: '盛岡市盛岡駅西通町２丁目９番地１号 マリオス10F',
+            'api-key': 'geolonia'
+        },
+        headers: {
+            'X-Access-Token': 'test'
+        }
+    }
+    // @ts-ignore
+     const lambdaResult = await promisify(handler)(event, {})
+    expect(Date.now() - now >= 1000).toBe(true)
+})
+
 test('should return 400 with empty address', async () => {
     const event = {
         queryStringParameters: null
@@ -87,7 +114,9 @@ test('should return 400 with empty address', async () => {
 test('should return 403 if authenticated.', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.authenticate = async () => { authenticated: false }
+    dynamodb.authenticate = async () => ({ authenticated: false })
+    dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
+    dynamodb.removeTimestamp = async (apiKey: string) => void 0
 
     const event = {
         queryStringParameters: {

--- a/src/public.ts
+++ b/src/public.ts
@@ -15,7 +15,7 @@ export const handler: EstateAPI.LambdaHandler = async (event, context, callback)
 
     const now = Date.now()
 
-    // [Alfa feature] Authenticate even if q['api-key'] not specified
+    // [Alfa feature] Authentication required anytime.
     if(!apiKey || !accessToken) {
         return callback(null, error(403, 'Incorrect querystring parameter `api-key` or `x-access-token` header value.'))
     } else {

--- a/src/public.ts
+++ b/src/public.ts
@@ -26,7 +26,7 @@ export const handler: EstateAPI.LambdaHandler = async (event, context, callback)
         if(lastRequestAt) {
             const diff = now - lastRequestAt
             if(diff < 1000) {
-                // delay the process and limt access rate
+                // Delay and limit access.
                 await sleep(1000)
             } else if(diff > 2000) {
                 // Uncontroled timestamp. An error may have occurred.
@@ -47,7 +47,7 @@ export const handler: EstateAPI.LambdaHandler = async (event, context, callback)
         return callback(null, error(500, 'Internal Server Error.'))
     }
 
-    // api key for Increment P should valid.
+    // API key for Increment P should valid.
     if(!result.ok) {
         if(result.status === 403) {
             process.stderr.write("API Authentication failed.\n")

--- a/src/public.ts
+++ b/src/public.ts
@@ -1,5 +1,5 @@
-import { authenticate, store, updateTimestamp, removeTimestamp } from './lib/dynamodb'
-import { decapitalize, verifyAddress, coord2XY, hashXY, getPrefCode, sleep } from './lib/index'
+import { authenticate, store, updateTimestamp } from './lib/dynamodb'
+import { decapitalize, verifyAddress, coord2XY, hashXY, getPrefCode } from './lib/index'
 import { error, json } from './lib/proxy-response'
 
 export const handler: EstateAPI.LambdaHandler = async (event, context, callback, isDebug = false) => {


### PR DESCRIPTION
API キーごとのレートリミットを追加しました。 同じ API キーで 3秒以内の連続したリクエストを送ると 429 Too many requests が帰るようになっています。