### PR TITLE
ID の振り直しの伴う仕様変更

### DIFF
--- a/bin/list-api-keys.mjs
+++ b/bin/list-api-keys.mjs
@@ -7,7 +7,11 @@ export const main = async (stage = 'dev') => {
     }
 
     const { Items: items = [] } = await docclient.scan(scanInput).promise()
-    const apiKeys = items.map(item => ({ ...item, accessToken: '****' }))
+    const apiKeys = items.map(item => ({
+      ...item,
+      accessToken: '****',
+      lastRequestAt: item.lastRequestAt ? new Date(item.lastRequestAt).toString() : null
+     }))
     process.stdout.write(JSON.stringify(apiKeys, null, 2) + '\n')
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "aws-sdk": "^2"
   },
   "scripts": {
-    "test": "ZOOM=24 jest",
+    "test": "ZOOM=22 jest",
     "build": "rimraf ./dist && tsc",
     "start": "npm run build && sls offline",
     "deploy:dev": "npm run build && sls deploy --stage=dev",

--- a/serverless.yml
+++ b/serverless.yml
@@ -92,17 +92,21 @@ resources:
             AttributeType: S
           - AttributeName: tile-xy
             AttributeType: S
+          - AttributeName: serial
+            AttributeType: N
         KeySchema:
           - AttributeName: estateId
             KeyType: HASH
-        BillingMode: PAY_PER_REQUEST
         GlobalSecondaryIndexes:
           - IndexName: tile-xy
             KeySchema:
               - AttributeName: tile-xy
                 KeyType: HASH
+              - AttributeName: serial
+                KeyType: RANGE
             Projection:
               ProjectionType: ALL
+        BillingMode: PAY_PER_REQUEST
 
 functions:
   public:

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,8 @@ provider:
     ZOOM: ${self:custom.zoomLevel}
     ACCESS_TOKEN_SALT: ${env:ACCESS_TOKEN_SALT}
     # IPC configs
-    INCREMENTP_VERIFICATION_API_ENDPOINT: ${cf:estate-id-api-cdn-${self:custom.stage}.BackendCDNEndpoint}
+    INCREMENTP_VERIFICATION_API_ENDPOINT: "https://api-anorm.mapfan.com/v1"
+    # INCREMENTP_VERIFICATION_API_ENDPOINT: ${cf:estate-id-api-cdn-${self:custom.stage}.BackendCDNEndpoint}
     INCREMENTP_VERIFICATION_API_KEY: ${env:INCREMENTP_VERIFICATION_API_KEY}
     # Internal Stack Refs
     AWS_DYNAMODB_API_KEY_TABLE_NAME: ${self:custom.awsDynamodbApiKeyTableName}
@@ -75,7 +76,7 @@ provider:
 custom:
   stage: ${opt:stage, self:provider.stage}
   # [ATTENTION] All Estate IDs will be changed If zoom altered.
-  zoomLevel: 24
+  zoomLevel: 22
   awsDynamodbApiKeyTableName: estate-id-api-key-${self:custom.stage}
   awsDynamodbEstateIdTableName: estate-id-${self:custom.stage}
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -50,6 +50,28 @@ provider:
               - Ref: "AWS::AccountId"
               - table/${self:custom.awsDynamodbEstateIdTableName}
 
+    - Effect: Allow
+      Action:
+        - dynamodb:queryItem
+      Resource:
+        - Fn::Join:
+            - ":"
+            - - arn:aws:dynamodb
+              - ${self:provider.region}
+              - Ref: "AWS::AccountId"
+              - table/${self:custom.awsDynamodbEstateIdTableName}/index/address-index
+
+    - Effect: Allow
+      Action:
+        - dynamodb:queryItem
+      Resource:
+        - Fn::Join:
+            - ":"
+            - - arn:aws:dynamodb
+              - ${self:provider.region}
+              - Ref: "AWS::AccountId"
+              - table/${self:custom.awsDynamodbEstateIdTableName}/index/tileXY-index
+
 custom:
   stage: ${opt:stage, self:provider.stage}
   # [ATTENTION] All Estate IDs will be changed If zoom altered.
@@ -61,7 +83,9 @@ package:
   exclude:
     - __tests__
     - .*
-    - src
+    - bin/
+    - docs/
+    - src/
     - package.json
     - README.md
     - serverless.yml
@@ -90,7 +114,9 @@ resources:
         AttributeDefinitions:
           - AttributeName: estateId
             AttributeType: S
-          - AttributeName: tile-xy
+          - AttributeName: address
+            AttributeType: S
+          - AttributeName: tileXY
             AttributeType: S
           - AttributeName: serial
             AttributeType: N
@@ -98,9 +124,15 @@ resources:
           - AttributeName: estateId
             KeyType: HASH
         GlobalSecondaryIndexes:
-          - IndexName: tile-xy
+          - IndexName: address-index
             KeySchema:
-              - AttributeName: tile-xy
+              - AttributeName: address
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
+          - IndexName: tileXY-index
+            KeySchema:
+              - AttributeName: tileXY
                 KeyType: HASH
               - AttributeName: serial
                 KeyType: RANGE

--- a/serverless.yml
+++ b/serverless.yml
@@ -52,7 +52,7 @@ provider:
 
     - Effect: Allow
       Action:
-        - dynamodb:queryItem
+        - dynamodb:Query
       Resource:
         - Fn::Join:
             - ":"
@@ -63,7 +63,7 @@ provider:
 
     - Effect: Allow
       Action:
-        - dynamodb:queryItem
+        - dynamodb:Query
       Resource:
         - Fn::Join:
             - ":"

--- a/serverless.yml
+++ b/serverless.yml
@@ -90,10 +90,19 @@ resources:
         AttributeDefinitions:
           - AttributeName: estateId
             AttributeType: S
+          - AttributeName: tile-xy
+            AttributeType: S
         KeySchema:
           - AttributeName: estateId
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
+        GlobalSecondaryIndexes:
+          - IndexName: tile-xy
+            KeySchema:
+              - AttributeName: tile-xy
+                KeyType: HASH
+            Projection:
+              ProjectionType: ALL
 
 functions:
   public:

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,8 +18,7 @@ provider:
     ZOOM: ${self:custom.zoomLevel}
     ACCESS_TOKEN_SALT: ${env:ACCESS_TOKEN_SALT}
     # IPC configs
-    INCREMENTP_VERIFICATION_API_ENDPOINT: "https://api-anorm.mapfan.com/v1"
-    # INCREMENTP_VERIFICATION_API_ENDPOINT: ${cf:estate-id-api-cdn-${self:custom.stage}.BackendCDNEndpoint}
+    INCREMENTP_VERIFICATION_API_ENDPOINT: ${cf:estate-id-api-cdn-${self:custom.stage}.BackendCDNEndpoint}
     INCREMENTP_VERIFICATION_API_KEY: ${env:INCREMENTP_VERIFICATION_API_KEY}
     # Internal Stack Refs
     AWS_DYNAMODB_API_KEY_TABLE_NAME: ${self:custom.awsDynamodbApiKeyTableName}

--- a/src/lib/__snapshots__/index.test.ts.snap
+++ b/src/lib/__snapshots__/index.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Should hash tile index as xxxx-xxxx-xxxx-xxxx 1`] = `"b2e1-1e3c-843e-65cf"`;
+exports[`Should hash tile index as xxxx-xxxx-xxxx-xxxx 1`] = `"63ac-3288-c7c2-66db"`;

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -35,35 +35,53 @@ export const updateTimestamp = async (apiKey:string, timestamp: number) => {
     return await docclient.update(updateItemInput).promise()
 }
 
-export const getNextSerial = async (x: number, y:number): Promise<number> => {
+export const issueSerial = async (x: number, y:number, address: string): Promise<number> => {
   const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
   const tileXY = `${x}/${y}`
 
-  const queryInput: AWS.DynamoDB.DocumentClient.QueryInput = {
+  const queryInputForExactMatch: AWS.DynamoDB.DocumentClient.QueryInput = {
     TableName: process.env.AWS_DYNAMODB_ESTATE_ID_TABLE_NAME,
-    IndexName: 'tile-xy',
+    IndexName: 'address-index',
     Limit: 1,
-    ExpressionAttributeNames: { '#t': 'tile-xy' },
+    ExpressionAttributeNames: { '#a': 'address' },
+    ExpressionAttributeValues: { ':a': address },
+    KeyConditionExpression: '#a = :a',
+  }
+  const { Items: exactMatchItems = [] } = await docclient.query(queryInputForExactMatch).promise()
+
+  if (exactMatchItems.length === 1) {
+    return exactMatchItems[0].serial;
+  }
+
+  // find serial
+  const queryInputForSerial: AWS.DynamoDB.DocumentClient.QueryInput = {
+    TableName: process.env.AWS_DYNAMODB_ESTATE_ID_TABLE_NAME,
+    IndexName: 'tileXY-index',
+    Limit: 1,
+    ExpressionAttributeNames: { '#t': 'tileXY' },
     ExpressionAttributeValues: { ':t': tileXY },
     ScanIndexForward: false, // descending
     KeyConditionExpression: '#t = :t'
   }
-  const { Items: items = [] } = await docclient.query(queryInput).promise()
-  if(items.length === 0) {
-    return 1
+
+  const { Items: serializedItems = [] } = await docclient.query(queryInputForSerial).promise()
+  if(serializedItems.length === 0) {
+    throw new Error('Unexpected error')
   } else {
-    return items[0].serial + 1
+    return serializedItems[0].serial + 1 // next serial number
   }
 }
 
-export const store = async (estateId: string, tileXY: string, serial: number, zoom: number, address: object) => {
+export const store = async (estateId: string, tileXY: string, serial: number, zoom: number, address: string) => {
     const docclient = new AWS.DynamoDB.DocumentClient({ apiVersion: '2012-08-10' })
     const putItemInput: AWS.DynamoDB.DocumentClient.PutItemInput = {
         TableName: process.env.AWS_DYNAMODB_ESTATE_ID_TABLE_NAME,
         Item: {
             estateId,
-            zoom: process.env.ZOOM,
-            address: JSON.stringify(address)
+            tileXY,
+            serial,
+            zoom,
+            address
         }
     }
     return await docclient.put(putItemInput).promise()

--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -66,7 +66,7 @@ export const issueSerial = async (x: number, y:number, address: string): Promise
 
   const { Items: serializedItems = [] } = await docclient.query(queryInputForSerial).promise()
   if(serializedItems.length === 0) {
-    throw new Error('Unexpected error')
+    return 0
   } else {
     return serializedItems[0].serial + 1 // next serial number
   }

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -3,7 +3,8 @@ import { hashXY, coord2XY, verifyAddress } from './index'
 test('Should hash tile index as xxxx-xxxx-xxxx-xxxx', () => {
     const indexX = 1234567
     const indexY = 54321
-    const digest = hashXY(indexX, indexY)
+    const serial = 100
+    const digest = hashXY(indexX, indexY, serial)
     expect(digest).toHaveLength(16 + 3) // 16 digits + 3 hyphens
     expect(digest.split('-').every(section => section.length === 4)).toBe(true)
     expect(digest).toMatchSnapshot()

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -22,10 +22,10 @@ test('Should calculate tile indexes from coordinates(1)', () => {
 test('Should calculate tile indexes from coordinates(2)', () => {
     const lat = 35.68122
     const lng = 139.76755
-    const { x, y } = coord2XY([lat, lng], 24)
-    // Those values are approximately x 2^(24 - 18) from the test above.
-    expect(x).toEqual(14902247)
-    expect(y).toEqual(6606499)
+    const { x, y } = coord2XY([lat, lng], 22)
+    // Those values are approximately x 2^(22 - 18) from the test above.
+    expect(x).toEqual(3725561)
+    expect(y).toEqual(1651624)
 })
 
 test('Should not calculate tile indexes with NaN', () => {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,8 +4,8 @@ import fetch from 'node-fetch'
 import * as crypto from 'crypto'
 import prefs from './prefs.json'
 
-export const hashXY = (x: number, y: number): string => {
-    const tileIdentifier = `${x}/${y}`
+export const hashXY = (x: number, y: number, serial: number): string => {
+    const tileIdentifier = `${x}/${y}/${serial}`
     const ahash64 = fnv.hash(tileIdentifier, 64).hex();
     return (ahash64.match(/.{4}/g) as string[]).join('-')
 }

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -15,6 +15,7 @@ test('should specify the ZOOM environmental variable.', () => {
 test.skip('should get estate ID', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
+    dynamodb.getNextSerial = async () => 100
     dynamodb.store = async () => void 0
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -39,6 +40,7 @@ test.skip('should get estate ID', async () => {
 test('should get estate ID with details if authenticated', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
+    dynamodb.getNextSerial = async () => 100
     dynamodb.authenticate = async () => ({ authenticated: true })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -59,7 +61,7 @@ test('should get estate ID with details if authenticated', async () => {
     const body = JSON.parse(lambdaResult.body)
     expect(body).toEqual([
         {
-            ID: "03-5759-4a9a-6195-71a0",
+            ID: "03-de11-8ea8-a10f-1324",
             "address": {
                 "ja": {
                     "address1": "盛岡駅西通2丁目",
@@ -81,6 +83,7 @@ test('should return 429 with too frequest request.', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
     const now = Date.now()
+    dynamodb.getNextSerial = async () => 100
     dynamodb.authenticate = async () => ({ authenticated: true, lastRequestAt: now })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -118,6 +121,7 @@ test('should return 403 if not authenticated.', async () => {
     dynamodb.authenticate = async () => ({ authenticated: false })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
+    dynamodb.getNextSerial = async () => 100
 
     const event = {
         queryStringParameters: {

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -61,7 +61,7 @@ test('should get estate ID with details if authenticated', async () => {
     const body = JSON.parse(lambdaResult.body)
     expect(body).toEqual([
         {
-            ID: "03-dd50-37a7-6daa-feea",
+            ID: "03-81b1-52e4-8c9e-d8d1",
             "address": {
                 "ja": {
                     "address1": "盛岡駅西通2丁目",

--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -15,7 +15,7 @@ test('should specify the ZOOM environmental variable.', () => {
 test.skip('should get estate ID', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.getNextSerial = async () => 100
+    dynamodb.issueSerial = async () => 100
     dynamodb.store = async () => void 0
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -40,7 +40,7 @@ test.skip('should get estate ID', async () => {
 test('should get estate ID with details if authenticated', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
-    dynamodb.getNextSerial = async () => 100
+    dynamodb.issueSerial = async () => 100
     dynamodb.authenticate = async () => ({ authenticated: true })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -83,7 +83,7 @@ test('should return 429 with too frequest request.', async () => {
     // mock
     const dynamodb = require('./lib/dynamodb')
     const now = Date.now()
-    dynamodb.getNextSerial = async () => 100
+    dynamodb.issueSerial = async () => 100
     dynamodb.authenticate = async () => ({ authenticated: true, lastRequestAt: now })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
@@ -121,7 +121,7 @@ test('should return 403 if not authenticated.', async () => {
     dynamodb.authenticate = async () => ({ authenticated: false })
     dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
     dynamodb.removeTimestamp = async (apiKey: string) => void 0
-    dynamodb.getNextSerial = async () => 100
+    dynamodb.issueSerial = async () => 100
 
     const event = {
         queryStringParameters: {

--- a/src/public.ts
+++ b/src/public.ts
@@ -63,7 +63,7 @@ export const handler: EstateAPI.LambdaHandler = async (event, context, callback,
     if(feature.geometry === null) {
         return callback(null, error(404, "The address '%s' is not verified.", address))
     }
-    // TODO: 正規化後のaddress 文字列を作る
+
     const normalizedAddress = feature.properties.place_name
 
     const [lng, lat] = feature.geometry.coordinates as [number, number]
@@ -96,13 +96,12 @@ export const handler: EstateAPI.LambdaHandler = async (event, context, callback,
     let body
     if(apiKey || isDemoMode) {
         // apiKey has been authenticated and return rich results
-        body = { ID: ID, address: addressObject, location }
+        body = { ID, address: addressObject, location }
     } else {
-        body = { ID: ID }
+        body = { ID }
     }
 
     try {
-      // 正規化後のaddress 文字列を渡す
         await store(ID,`${x}/${y}`, nextSerial, ZOOM, normalizedAddress)
     } catch (error) {
         console.error({ ID, ZOOM, addressObject, apiKey, error })


### PR DESCRIPTION
- ズームを22に変更
- ハッシュのアルゴリズムを SHA256 に変更
- 同じタイルで別の住所に対しては連番を発行し、ハッシュの種として使うことで別のIDを発行できる様に修正