### PR TITLE
Fix test

### DIFF
--- a/src/public.test.ts
+++ b/src/public.test.ts
@@ -82,7 +82,7 @@ test('should get estate ID with details if authenticated', async () => {
 test('should get estate ID with details if authenticated, and geocodeing-level is 7 (番地でマッチ：号情報が存在しない地域）', async () => {
   // mock
   const dynamodb = require('./lib/dynamodb')
-  dynamodb.issueSerial = async () => 100
+  dynamodb.issueSerial = async () => 0
   dynamodb.authenticate = async () => ({ authenticated: true })
   dynamodb.updateTimestamp = async (apiKey: string, timestamp: number) => void 0
   dynamodb.removeTimestamp = async (apiKey: string) => void 0


### PR DESCRIPTION
モックの値を修正。 `兵庫県姫路市玉手2丁目465` は建物名がないから、連番は `0` が割り当てられている可能性が高い。したがって `0` をとりあえず指定し、本番環境と合わせることでテストが通るようにした。