### PR TITLE
Update NJA to v1.0.2, change error response type to include level detail

### DIFF
--- a/src/lib/dynamodb_logs.ts
+++ b/src/lib/dynamodb_logs.ts
@@ -1,7 +1,7 @@
 import { DB } from "./dynamodb"
 import { ulid } from "ulid"
 
-export const createLog = async (identifier: string, metadata: { [key: string]: string }, now: Date = new Date()): Promise<void> => {
+export const createLog = async (identifier: string, metadata: { [key: string]: any }, now: Date = new Date()): Promise<void> => {
   const nowStr = now.toISOString()
   const datePart = nowStr.slice(0, 10)
   const PK = `LOG#${identifier}#${datePart}`

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -115,8 +115,8 @@ export const yokobo2zenchoonSymbol = (str: string) => {
   return str.replace(/[-－﹣−‐⁃‑‒–—﹘―⎯⏤ーｰ─━]/gi,'ー') // 長音記号に変換
 }
 
-export const normalizeBuilding = (building: string | undefined ): string | undefined => {
-  if(undefined === building) {
+export const normalizeBuilding = (building?: string ): string | undefined => {
+  if (typeof building === 'undefined' || building.trim() === "") {
     return undefined
   }
   return yokobo2zenchoonSymbol(zen2hanAscii(building.trim()))

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,9 +310,9 @@
   integrity sha512-LO1f4Bw/UF5OIWAavX9CyclxYCsHPDe6h/CWL/1RInc3QLMkEGicZp++qyfjodDsPKMCs84GReJapQnPWl3ZUQ==
 
 "@geolonia/normalize-japanese-addresses@*":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@geolonia/normalize-japanese-addresses/-/normalize-japanese-addresses-0.1.9.tgz#59aa9597dafcb4170c31b947bfac7833b1f8e24f"
-  integrity sha512-/D+D5GjrjmR34N1S5p/sbRsortR0fGYncdWLJMUADvEZUzo4mP6fSwbfEDXS7Rz9W9+bFbRpKC1piRBY+iehwg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@geolonia/normalize-japanese-addresses/-/normalize-japanese-addresses-1.0.2.tgz#e1bab3443265b1288e9798aa6e9de1509222431b"
+  integrity sha512-KfewiWewUhrAkzrvQeqFH+AXonCqDRjGlR18qiXmA78gtq0GzyeXIZHCowMY3iwd1wRaEZ6PgZXA+FLNvUCCJQ==
   dependencies:
     "@geolonia/japanese-numeral" "^0.1.11"
     node-fetch "^2.6.1"


### PR DESCRIPTION
最低条件の正規化失敗した時に、`can not be normalized` エラーから `error_code: normalization_failed, error_code_detail: city_not_recognized|prefecture_not_recognized` に変更。
テストツールUIも合わせて「都道府県を認識できませんでした」「市区町村を認識できませんでした」を追加したほうがいいですね

Closes #128